### PR TITLE
Upgrade arm-none-eabi-gcc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,14 @@
 FROM ubuntu:18.04
 RUN apt-get update
-RUN apt-get -y install scons gcc-arm-none-eabi gcc-msp430 python-pip sudo
 RUN apt-get -y upgrade
+RUN apt-get -y install scons gcc-msp430 python-pip sudo
+
+# The official package of gcc-arm-none-eabi by Ubuntu is kind of
+# old. Use a package by "GCC Arm Embedded Maintainers" team
+RUN apt-get -y install software-properties-common
+RUN add-apt-repository ppa:team-gcc-arm-embedded/ppa
+RUN apt-get update
+RUN apt-get -y install gcc-arm-embedded
 
 RUN useradd user
 RUN echo '%user ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM ubuntu:18.04
 RUN apt-get update
 RUN apt-get -y install scons gcc-arm-none-eabi gcc-msp430 python-pip sudo
+RUN apt-get -y upgrade
 
 RUN useradd user
 RUN echo '%user ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:18.04
 RUN apt-get update
-RUN apt-get -y install scons gcc-arm-none-eabi gcc-msp430 sudo
+RUN apt-get -y install scons gcc-arm-none-eabi gcc-msp430 python-pip sudo
 
 RUN useradd user
 RUN echo '%user ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers

--- a/README.md
+++ b/README.md
@@ -70,4 +70,4 @@ $ docker run --mount type=bind,source=/Users/foo/Work/openwsn-fw,destination=/ho
 ## How to Build your own Docker image
 1. clone this repository
 1. edit `Dockerfile` as you want
-1. run `$ docker build .`
+1. run `$ docker build .` or `$ docker build --no-cache .`


### PR DESCRIPTION
This PR upgrades `arm-none-eabi-gcc` installed on the docker image.

Using `gcc-arm-none-eabi` provided by Ubuntu, I cannot build a firmware for [M3 Open Mote](https://www.iot-lab.info/hardware/m3/) for some reasons. With the same source code, an IAR compiler succeeds to build a working firmware. [Two versions of "GNU toolchain for ARM" available at a FIT IoT/LAB ssh host](https://github.com/iot-lab/iot-lab/wiki/Versions-of-the-GNU-toolchain-for-ARM) do the same.

So, I tried a newer `gcc-arm-none-eabi`, which is provided by "GCC Arm Embedded Maintainers" team. This works fine 👍  

This is the current version (without a change by this PR):
```
user@0bb6cbd49e29:~/openwsn-fw$ arm-none-eabi-gcc --version
arm-none-eabi-gcc (15:6.3.1+svn253039-1build1) 6.3.1 20170620
Copyright (C) 2016 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```

This is the upgraded version (with the PR's change):
```
user@a00d3a081ea5:~/openwsn-fw$ arm-none-eabi-gcc --version
arm-none-eabi-gcc (GNU Tools for Arm Embedded Processors 7-2018-q3-update) 7.3.1 20180622 (release) [ARM/embedded-7-branch revision 261907]
Copyright (C) 2017 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```